### PR TITLE
Make compatible with InfluxDB 1.0.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ under the License.
 		<dependency>
 			<groupId>org.influxdb</groupId>
 			<artifactId>influxdb-java</artifactId>
-			<version>2.2</version>
+			<version>2.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/src/main/java/com/dataartisans/sinks/InfluxDBSink.java
+++ b/src/main/java/com/dataartisans/sinks/InfluxDBSink.java
@@ -46,6 +46,6 @@ public class InfluxDBSink<T extends DataPoint<? extends Number>> extends RichSin
 
     Point p = builder.build();
 
-    influxDB.write(dataBaseName, "default", p);
+    influxDB.write(dataBaseName, "autogen", p);
   }
 }


### PR DESCRIPTION
Original project code is incompatible with InfluxDB 1.0.0 which at the time of writing is the default version installed when using homebew as suggested in the [tutorial](http://data-artisans.com/robust-stream-processing-flink-walkthrough/).

I merely updated the InfluxDB driver version and changed the policy name used in write requests, since `default` does not seem to exist anymore.
