### PR TITLE
upgrade base image of grafana_setup image

### DIFF
--- a/docker/grafana_setup/Dockerfile
+++ b/docker/grafana_setup/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:jessie
 
 ADD dashboard.json /tmp
 ADD influxdb_datasource.json /tmp


### PR DESCRIPTION
Wheezy repositories are not available anymore, so image can not be built without upgrading to jessie